### PR TITLE
Allow unregistered hosts to send logs to logentries.

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -34,6 +34,16 @@ class logentries::agent {
       require => Package['logentries-daemon'],
       notify  => Service['logentries'],
     }
+  } elsif ( $logentries::params::agent_key == '' ) and ( $logentries::params::register == false ) {
+    # Basic configuration which only sends logs. Does not register host in UI. Useful with auto scaling. Has to be used with agent::follow and destination parameter.
+    file { '/etc/le/config':
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0640',
+      content => "[Main]\nuser-key = ${logentries::params::account_key}\npull-server-side-config = False\n",
+      require => Package['logentries-daemon'],
+      notify  => Service['logentries'],
+    }
   } else {
     exec { '/usr/bin/le register':
       command => "/usr/bin/le register ${use_server_config_arg}${datahub_config_arg} --account-key=${logentries::params::account_key}${agent_key_config_arg}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class logentries (
   $account_key,
   $agent_key = '',
   $datahub = '',
+  $register = true,
   $use_server_config = false,
   $manage_repos = true
 ) {
@@ -19,6 +20,7 @@ class logentries (
     agent_key         => $agent_key,
     datahub           => $datahub,
     use_server_config => $use_server_config,
+    register          => $register, 
   }
   if $manage_repos {
     include logentries::repo

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,8 @@ class logentries::params (
   $account_key,
   $agent_key,
   $datahub,
-  $use_server_config
+  $use_server_config,
+  $register,
 ) {
   $configured = true
 }


### PR DESCRIPTION
New parameter 'register' used with empty 'agent_key' allows unregistered a host to send logs to location set by 'destination' parameter in logentries::agent::follow resource.
